### PR TITLE
Add more Outlook URLs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,12 @@
 
   "content_scripts": [
     {
-      "matches": ["*://*.outlook.live.com/*"],
+      "matches": [
+      	"*://*.outlook.live.com/*",
+       "*://*.outlook.office.com/*",
+       "*://*.outlook.office365.com/*",
+       "*://*.outlook.cloud.microsoft/*"
+      ],
       "js": ["./src/outlook_web_plus_min.js"]
     }
   ],


### PR DESCRIPTION
I couldn't use the extension on my work Outlook account, because the URL was `outlook.cloud.microsoft` instead of `outlook.live.com`. I added `outlook.office.com`, `outlook.office365.com` and `outlook.cloud.microsoft` to `manifest.json`, and it works in my Firefox.